### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-platformio.yml
+++ b/.github/workflows/build-platformio.yml
@@ -3,6 +3,9 @@ name: Build PlatformIO project
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,6 +3,9 @@ name: Linter
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   prettier:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Unit tests
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   test-platformio:
     name: Test PlatformIO


### PR DESCRIPTION
Potential fix for [https://github.com/havardAasen/BrewPiLess/security/code-scanning/6](https://github.com/havardAasen/BrewPiLess/security/code-scanning/6)

Add an explicit top-level `permissions` block in `.github/workflows/linter.yml` so all jobs inherit minimal token access.

Best fix (without changing functionality):
- Insert at workflow root (after `on:` block, before `jobs:`):
  - `permissions:`
  - `contents: read`

Why this is best:
- All current jobs only need repository read access (checkout + lint commands).
- One root block is simpler and less error-prone than repeating per job.
- Behavior remains the same for linting, but token scope is now explicitly restricted.

No imports, methods, or dependencies are needed since this is YAML workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
