### PR TITLE
Switch out SimpleFilter for ExponentialSmoothing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 cheader/
 compile_commands.json
 dist/
+doc/html/
 node_modules/

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,29 @@
+PROJECT_NAME           = "BrewPiLess"
+OUTPUT_DIRECTORY       = doc
+CREATE_SUBDIRECTORIES  = YES
+
+INPUT                  = src lib
+RECURSIVE              = YES
+FILE_PATTERNS          = *.cpp *.h
+
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+GENERATE_LATEX         = NO
+USE_MATHJAX            = YES
+
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = YES
+EXTRACT_STATIC         = YES
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = NO
+SEARCH_INCLUDES        = YES
+
+HAVE_DOT               = YES
+CALL_GRAPH             = YES
+CALLER_GRAPH           = YES
+UML_GRAPH              = YES
+
+SOURCE_BROWSER         = YES
+INLINE_SOURCES         = NO

--- a/lib/Filter/ExponentialSmoothing.h
+++ b/lib/Filter/ExponentialSmoothing.h
@@ -1,0 +1,51 @@
+#ifndef BREWPILESS_EXPONENTIALSMOOTHING_H
+#define BREWPILESS_EXPONENTIALSMOOTHING_H
+
+/**
+ * @addtogroup filters
+ * @{
+ *
+ * @class ExponentialSmoothing
+ * @brief Simple exponential smoothing (single‑pole IIR) filter.
+ *
+ * The filter maintains an internal state \f$S_t\f$ that is updated with each
+ * new sample \f$x_t\f$ according to
+ *
+ * \f[
+ * S_t = S_{t-1} + \alpha (x_t - S_{t-1})
+ * \f]
+ *
+ * where
+ *
+* \f[
+ * 0 < \alpha \le 1
+ * \f]
+ *
+ * Smaller \f$\alpha\f$ gives more smoothing (longer memory); \f$\alpha = 1.0\f$
+ * passes the input through unchanged.
+ */
+class ExponentialSmoothing
+{
+public:
+    explicit ExponentialSmoothing(const float alpha = 0.1f)
+        : output_(0.0f), alpha_(alpha) {}
+
+    void setInitial(const float value) noexcept { output_ = value; }
+
+    void setAlpha(const float alpha) noexcept { alpha_ = alpha; }
+    [[nodiscard]] float alpha() const noexcept { return alpha_; }
+    [[nodiscard]] float addSample(const float x) noexcept
+    {
+        output_ += alpha_ * (x - output_);
+        return output_;
+    }
+
+    /** Retrieve the current filtered value without updating. */
+    [[nodiscard]] float output() const noexcept { return output_; }
+
+private:
+    float output_;   ///< Current filtered output \f$S_{n-1}\f$
+    float alpha_;    ///< Smoothing factor \f$\alpha\f$
+};
+
+#endif

--- a/lib/Temperature/TemperatureFormats.cpp
+++ b/lib/Temperature/TemperatureFormats.cpp
@@ -79,7 +79,7 @@ long_temperature stringToFixedPoint(const char * numberString){
 	long_temperature intPart = 0;
 	long_temperature fracPart = 0;
 
-	char * fractPtr = nullptr; //pointer to the point in the string
+	const char *fractPtr = nullptr; //pointer to the point in the string
 	bool negative = 0;
 	if(numberString[0] == '-'){
 		numberString++;

--- a/src/BPLSettings.cpp
+++ b/src/BPLSettings.cpp
@@ -176,7 +176,7 @@ String BPLSettings::jsonSystemConfiguration(){
 #define KeyCoefficientA1 "a1"
 #define KeyCoefficientA2 "a2"
 #define KeyCoefficientA3 "a3"
-#define KeyLPFBeta "lpc"
+#define KeyLPFAlpha "lpc"
 #define KeyStableGravityThreshold "stpt"
 #define KeyNumberCalPoints "npt"
 #define KeyUsePlato "plato"
@@ -200,7 +200,7 @@ String BPLSettings::jsonSystemConfiguration(){
 	gdc->ispindelCoefficients[1]=doc[KeyCoefficientA1];
 	gdc->ispindelCoefficients[2]=doc[KeyCoefficientA2];
 	gdc->ispindelCoefficients[3]=doc[KeyCoefficientA3];
-	gdc->lpfBeta =doc[KeyLPFBeta];
+	gdc->lpfAlpha =doc[KeyLPFAlpha];
 	gdc->stableThreshold=doc[KeyStableGravityThreshold];
 	gdc->numberCalPoints=doc[KeyNumberCalPoints];
 	gdc->usePlato = doc[KeyUsePlato].is<bool>() ? doc[KeyUsePlato] : false;
@@ -226,7 +226,7 @@ String BPLSettings::jsonGravityConfig(){
 
 		doc[KeyCorrectionTemp] = gdc->ispindelCalibrationBaseTemp;
 		doc[KeyCalculateGravity] = gdc->calculateGravity;
-		doc[KeyLPFBeta] =gdc->lpfBeta;
+		doc[KeyLPFAlpha] =gdc->lpfAlpha;
 		doc[KeyStableGravityThreshold] = gdc->stableThreshold;
 
 		doc[KeyCoefficientA0]=gdc->ispindelCoefficients[0];

--- a/src/BPLSettings.h
+++ b/src/BPLSettings.h
@@ -48,7 +48,7 @@ struct TimeInformation{
 //  36
 struct GravityDeviceConfiguration{
     std::array<float, 4> ispindelCoefficients{};
-    float    lpfBeta{0.1};
+    float    lpfAlpha{0.1};
     uint32_t numberCalPoints{0};
 
     uint8_t  ispindelEnable{0};

--- a/src/BPLSettings.h
+++ b/src/BPLSettings.h
@@ -47,7 +47,7 @@ struct TimeInformation{
 // gravity device
 //  36
 struct GravityDeviceConfiguration{
-    std::array<float, 4> ispindelCoefficients;
+    std::array<float, 4> ispindelCoefficients{};
     float    lpfBeta{0.1};
     uint32_t numberCalPoints{0};
 

--- a/src/BrewPiLess.cpp
+++ b/src/BrewPiLess.cpp
@@ -607,7 +607,6 @@ void setup(void){
 
 	webServer->addHandler(&logHandler);
 
-	externalDataHandler.loadConfig();
 	webServer->addHandler(&externalDataHandler);
 
 	webServer->addHandler(&networkConfig);

--- a/src/ExternalData.cpp
+++ b/src/ExternalData.cpp
@@ -73,12 +73,6 @@ void ExternalData::sseNotify(char *buf){
 }
 
 
-void ExternalData::loadConfig(){
-    _cfg = theSettings.GravityConfig();
-    filter.setBeta(_cfg->lpfBeta);
-}
-
-
 bool ExternalData::processconfig(char* configdata){
    bool ret= theSettings.dejsonGravityConfig(configdata);
    if(ret){
@@ -107,6 +101,14 @@ void ExternalData::setOriginalGravity(float og){
 		brewKeeper.updateOriginalGravity(og);
 #endif
 }
+
+
+ExternalData::ExternalData()
+{
+    _cfg = theSettings.GravityConfig();
+    filter.setBeta(_cfg->lpfBeta);
+}
+
 
 void ExternalData::setTilt(float tilt,float temp,time_t now){
 	_lastUpdate=now;

--- a/src/ExternalData.cpp
+++ b/src/ExternalData.cpp
@@ -106,7 +106,7 @@ void ExternalData::setOriginalGravity(float og){
 ExternalData::ExternalData()
 {
     _cfg = theSettings.GravityConfig();
-    filter.setAlpha(_cfg->lpfBeta);
+    filter.setAlpha(_cfg->lpfAlpha);
 }
 
 

--- a/src/ExternalData.cpp
+++ b/src/ExternalData.cpp
@@ -156,7 +156,7 @@ void ExternalData::setGravity(float sg, time_t now,bool log){
 
 	if(!IsGravityValid(old_sg)) filter.setInitial(sg);
 #if EnableGravitySchedule
-    float _filteredGravity=filter.addData(sg);
+	_filteredGravity=filter.addData(sg);
 		// use filter data as input to tracker and beer profile.
 	brewKeeper.updateGravity(_filteredGravity);
 	if(_cfg->usePlato)

--- a/src/ExternalData.cpp
+++ b/src/ExternalData.cpp
@@ -38,7 +38,7 @@ void ExternalData::sseNotify(char *buf){
 		strgravity[len]='\0';
 
 		char slowpassfilter[8];
-		len=sprintf(slowpassfilter, "%.*f", 2, filter.beta());
+		len=sprintf(slowpassfilter, "%.*f", 2, filter.alpha());
 		slowpassfilter[len]='\0';
 
 		char strtilt[8];
@@ -106,7 +106,7 @@ void ExternalData::setOriginalGravity(float og){
 ExternalData::ExternalData()
 {
     _cfg = theSettings.GravityConfig();
-    filter.setBeta(_cfg->lpfBeta);
+    filter.setAlpha(_cfg->lpfBeta);
 }
 
 
@@ -156,7 +156,7 @@ void ExternalData::setGravity(float sg, time_t now,bool log){
 
 	if(!IsGravityValid(old_sg)) filter.setInitial(sg);
 #if EnableGravitySchedule
-	_filteredGravity=filter.addData(sg);
+	_filteredGravity=filter.addSample(sg);
 		// use filter data as input to tracker and beer profile.
 	brewKeeper.updateGravity(_filteredGravity);
 	if(_cfg->usePlato)

--- a/src/ExternalData.h
+++ b/src/ExternalData.h
@@ -71,6 +71,8 @@ protected:
 	void setAuxTemperatureCelsius(float temp);
 	void setOriginalGravity(float og);	
 public:
+	explicit ExternalData();
+
 	float gravity(bool filtered=false);
 	float plato(bool filtered=false);
 
@@ -84,7 +86,6 @@ public:
     void sseNotify(char *buf);
 	//configuration processs
     bool processconfig(char* configdata);
-	void loadConfig();
 	//update formula
 	void formula(float coeff[4],uint32_t npt);
 

--- a/src/ExternalData.h
+++ b/src/ExternalData.h
@@ -10,6 +10,7 @@
 #include "TempSensorWireless.h"
 #endif
 
+#include <ExponentialSmoothing.h>
 #include <TemperatureFormats.h>
 
 #define INVALID_VOLTAGE -1
@@ -30,21 +31,6 @@ inline bool isTiltAngleValid(const float angle) { return angle > 0; }
 #define ErrorUnknownSource 4
 
 
-class SimpleFilter
-{
-	float _y{};
-	float _b{0.1};
-public:
-	void setInitial(float v){ _y=v;}
-	void setBeta(float b) { _b = b; }
-	float beta(){ return _b; }
-
-	float addData(float x){
-		_y = _y + _b * (x - _y);
-		return _y;
-	}
-};
-
 class ExternalData
 {
 protected:
@@ -53,7 +39,7 @@ protected:
 	time_t _lastUpdate{};
 	float  _deviceVoltage{INVALID_VOLTAGE};
 //	float _og;
-	SimpleFilter filter;
+	ExponentialSmoothing filter;
 	char *_ispindelName{};
 	float _ispindelTilt{-1};
 	bool  _calibrating{};

--- a/src/WebHandler/ExternalDataHandler.cpp
+++ b/src/WebHandler/ExternalDataHandler.cpp
@@ -21,12 +21,6 @@ bpl::webHandler::ExternalDataHandler::ExternalDataHandler()
 }
 
 
-void bpl::webHandler::ExternalDataHandler::loadConfig()
-{
-    externalData.loadConfig();
-}
-
-
 bool bpl::webHandler::ExternalDataHandler::canHandle(AsyncWebServerRequest *request) const
 {
     DBG_PRINTF("req: %s\n", request->url().c_str());

--- a/src/WebHandler/ExternalDataHandler.h
+++ b/src/WebHandler/ExternalDataHandler.h
@@ -16,8 +16,6 @@ namespace bpl::webHandler {
                         size_t total) override;
         [[nodiscard]] bool isRequestHandlerTrivial() const override;
 
-        void loadConfig();
-
     private:
         void processGravity(AsyncWebServerRequest *request, char data[], size_t length);
 

--- a/test/test_filter/test_exponentialSmoothing.cpp
+++ b/test/test_filter/test_exponentialSmoothing.cpp
@@ -1,0 +1,58 @@
+/*
+* SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (C) 2026 Håvard F. Aasen
+ */
+
+#include <ExponentialSmoothing.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(ExponentialSmoothing, DefaultConstruction)
+{
+    const ExponentialSmoothing filter;
+    EXPECT_FLOAT_EQ(filter.alpha(), 0.1f);
+    EXPECT_FLOAT_EQ(filter.output(), 0.0f);
+}
+
+TEST(ExponentialSmoothing, SetInitial)
+{
+    ExponentialSmoothing filter;
+    filter.setInitial(5.0f);
+    EXPECT_FLOAT_EQ(filter.output(), 5.0f);
+}
+
+TEST(ExponentialSmoothing, AlphaSetterGetter)
+{
+    ExponentialSmoothing filter;
+    filter.setAlpha(0.75f);
+    EXPECT_FLOAT_EQ(filter.alpha(), 0.75f);
+}
+
+TEST(ExponentialSmoothing, SingleUpdate)
+{
+    ExponentialSmoothing filter(0.2f);
+    filter.setInitial(1.0f);
+    const float y = filter.addSample(3.0f);   // y = 1 + 0.2*(3-1) = 1.4
+    EXPECT_FLOAT_EQ(y, 1.4f);
+    EXPECT_FLOAT_EQ(filter.output(), 1.4f);
+}
+
+TEST(ExponentialSmoothing, MultipleUpdates)
+{
+    ExponentialSmoothing filter(0.5f);
+    filter.setInitial(0.0f);
+    const std::vector in  = {2.0f, 4.0f, 6.0f};
+    const std::vector out = {1.0f, 2.5f, 4.25f}; // known EMA values
+
+    for (size_t i = 0; i < in.size(); ++i) {
+        EXPECT_FLOAT_EQ(filter.addSample(in[i]), out[i]);
+    }
+}
+
+TEST(ExponentialSmoothing, AlphaOnePassesThrough)
+{
+    ExponentialSmoothing filter(1.0f);
+    filter.setInitial(0.0f);
+    EXPECT_FLOAT_EQ(filter.addSample(7.3f), 7.3f);
+    EXPECT_FLOAT_EQ(filter.addSample(-2.1f), -2.1f);
+}


### PR DESCRIPTION
Renames the class `SimpleFilter` to `ExponentialSmoothing` and places it in `lib/`. Also added unit tests and doxygen comments. Functionality is identical to what is was before.

I have also included a Doxygen file, but there is no intention to document each function.

Two minor bug fixes, member variable which was shadowed by a local variable, and a return value missing `const`. This last issue made the tests fail locally.