### PR TITLE
Fix remote log form and regex for whitespace

### DIFF
--- a/frontend/src/js/script-logging.js
+++ b/frontend/src/js/script-logging.js
@@ -1,4 +1,4 @@
-import { select, C2F, BrewMath, updateNavbarVersion } from "./shared";
+import { select, C2F, BrewMath, updateNavbarVersion, byId } from "./shared";
 import { mqttLoadSetting } from "./mqtt";
 import { del, get, post } from "./httpClient";
 
@@ -246,7 +246,7 @@ function generichttp_get() {
         alert("<%= script_logging_select_method %>");
         return null;
     }
-    var format = select("#format").value.trim();
+    const format = byId("format").value.trim();
 
     if (window.selectedMethod == "GET") {
         const myRe = /s/g;

--- a/frontend/src/js/script-logging.js
+++ b/frontend/src/js/script-logging.js
@@ -249,7 +249,7 @@ function generichttp_get() {
     var format = select("#format").value.trim();
 
     if (window.selectedMethod == "GET") {
-        var myRe = new RegExp("\s", "g");
+        const myRe = /s/g;
         if (myRe.exec(format)) {
             alert("<%= script_logging_space_not_allowed %>");
             return null;

--- a/frontend/src/js/script-logging.js
+++ b/frontend/src/js/script-logging.js
@@ -231,12 +231,12 @@ function checkformat(ta) {
     select("#fmthint").innerHTML = "" + ta.value.length + "/256";
 }
 
-function cmethod(c) {
-    var inputs = document.querySelectorAll('input[name$="method"]');
-    for (var i = 0; i < inputs.length; i++) {
-        if (inputs[i].id != c.id) inputs[i].checked = false;
-    }
-    window.selectedMethod = c.value;
+/**
+ * @param {HTMLInputElement} radioBtn
+ */
+function updateRemoteLogHttpMethod(radioBtn) {
+    const labelEl = select(`label[for="${radioBtn.id}"]`);
+    window.selectedMethod = labelEl.textContent.trim();
 }
 
 //Serivce specif widget processing
@@ -494,6 +494,20 @@ async function remote_init() {
     };
 
     serviceOption("generichttp");
+    const checkedRadioBtn = select('input[name="method"]:checked');
+    if (checkedRadioBtn) {
+        updateRemoteLogHttpMethod(checkedRadioBtn);
+    }
+
+    const radioBtns = document.querySelectorAll('input[name="method"]');
+    radioBtns.forEach((r) => {
+        r.addEventListener("change", () => {
+            // The radio button that fired the event is now the checked one
+            if (r.checked) {
+                updateRemoteLogHttpMethod(r);
+            }
+        });
+    });
 
     let json;
     try {
@@ -562,7 +576,6 @@ export function init() {
 }
 
 window.checkurl = checkurl;
-window.cmethod = cmethod;
 window.hideformat = hideformat;
 window.serviceChange = serviceChange;
 window.showformat = showformat;

--- a/frontend/src/logging.tmpl.html
+++ b/frontend/src/logging.tmpl.html
@@ -406,15 +406,15 @@
                                 <%= log_method %>
                             </h6>
                             <div class="md-radio md-radio-inline">
-                                <input id="m_get" type="radio" name="method" checked onchange="cmethod(this);">
+                                <input id="m_get" type="radio" name="method" checked>
                                 <label for="m_get">GET</label>
                             </div>
                             <div class="md-radio md-radio-inline">
-                                <input id="m_post" type="radio" name="method" onchange="cmethod(this);">
+                                <input id="m_post" type="radio" name="method">
                                 <label for="m_post">POST</label>
                             </div>
                             <div class="md-radio md-radio-inline">
-                                <input id="m_put" type="radio" name="method" onchange="cmethod(this);">
+                                <input id="m_put" type="radio" name="method">
                                 <label for="m_put">PUT</label>
                             </div>
                         </div>

--- a/frontend/src/logging.tmpl.html
+++ b/frontend/src/logging.tmpl.html
@@ -364,13 +364,13 @@
                             <h6 class="inline-header">
                                 <%= log_brewfather_id %>
                             </h6>
-                            <input type="text" id="brewfather-id" required size="42">
+                            <input type="text" id="brewfather-id" size="42">
                         </div>
                         <div layout horizontal cross-center>
                             <h6 class="inline-header">
                                 <%= log_brewfather_device_label %>
                             </h6>
-                            <input type="text" id="brewfather-device" required size="42">
+                            <input type="text" id="brewfather-device" size="42">
                         </div>
                     </div>
 


### PR DESCRIPTION
Improvements related to remote logging.
- Removed 'required' for possible hidden fields
- Fix regex meant to match spaces
- Take HTML field by ID
- Fix radio buttons for remote log and generic HTTP